### PR TITLE
Generalization of One_critical_filtration

### DIFF
--- a/src/Multi_filtration/include/gudhi/One_critical_filtration.h
+++ b/src/Multi_filtration/include/gudhi/One_critical_filtration.h
@@ -5,20 +5,23 @@
  *    Copyright (C) 2023 Inria
  *
  *    Modification(s):
+ *      - 2024/08 Hannah Schreiber: Generalization to all arithmetic types for T
  *      - YYYY/MM Author: Description of the modification
  */
 
 #ifndef ONE_CRITICAL_FILTRATIONS_H_
 #define ONE_CRITICAL_FILTRATIONS_H_
 
-#include <algorithm>
-#include <cmath>
-#include <cstddef>
-#include <cstdint>
-#include <functional>
-#include <iostream>
-#include <limits>
+#include <algorithm>  //std::lower_bound
+#include <cmath>      //std::isnan
+#include <cstddef>    //std::size_t
+#include <cstdint>    //std::int32_t
+#include <ostream>    //std::ostream
+#include <limits>     //std::numerical_limits
+#include <stdexcept>  //std::logic_error
 #include <vector>
+
+#include <gudhi/Debug_utils.h>
 
 namespace Gudhi::multi_filtration {
 
@@ -39,244 +42,457 @@ namespace Gudhi::multi_filtration {
  * x>=(2,1)\} \f$ is finitely critical, and more particularly 2-critical, while
  *  - \f$ \{ x \in  \mathbb R^2 : x>= \mathrm{epigraph}(y\mapsto e^{-y})\} \f$
  * is not.
- * Use \ref Multi_critical_filtration for multicritical filtrations.
- * \tparam T value type of the vector-like.
+ * Use \ref Multi_critical_filtration for multi-critical filtrations.
+ * \tparam T value type of the vector-like. Has to implement std::isnan(), std::numeric_limits<T>::has_quiet_NaN,
+ * std::numeric_limits<T>::quiet_NaN(), std::numeric_limits<T>::has_infinity, std::numeric_limits<T>::infinity(),
+ * std::numeric_limits<T>::max().
  */
 template <typename T>
-class One_critical_filtration : public std::vector<T> {
+class One_critical_filtration : public std::vector<T>
+{
+ private:
+  using Base = std::vector<T>;
+
  public:
-  One_critical_filtration() : std::vector<T>() {};
-  One_critical_filtration(int n) : std::vector<T>(n, -T_inf) {};  // minus infinity by default
-  One_critical_filtration(int n, T value) : std::vector<T>(n, value) {};
-  One_critical_filtration(std::initializer_list<T> init) : std::vector<T>(init) {};
-  One_critical_filtration(const std::vector<T> &v) : std::vector<T>(v) {};
-  One_critical_filtration(std::vector<T> &&v) : std::vector<T>(std::move(v)) {};
+  template <typename U = T>
+  using Single_point = One_critical_filtration<U>;
+
+  // CONSTRUCTORS
+
+  One_critical_filtration() : Base() {};
+  // warning: can be problematic if the user never updates the values and let it like that, {-inf, -inf, ...} is not
+  // considered as -inf.
+  One_critical_filtration(int n) : Base(n, -T_inf) {};  // minus infinity by default
+  One_critical_filtration(int n, T value) : Base(n, value) {};
+  One_critical_filtration(std::initializer_list<T> init) : Base(init) {};
+  One_critical_filtration(const std::vector<T> &v) : Base(v) {};
+  One_critical_filtration(std::vector<T> &&v) : Base(std::move(v)) {};
   One_critical_filtration(typename std::vector<T>::iterator it_begin, typename std::vector<T>::iterator it_end)
-      : std::vector<T>(it_begin, it_end) {};
+      : Base(it_begin, it_end) {};
   One_critical_filtration(typename std::vector<T>::const_iterator it_begin,
                           typename std::vector<T>::const_iterator it_end)
-      : std::vector<T>(it_begin, it_end) {};
+      : Base(it_begin, it_end) {};
+
+  One_critical_filtration &operator=(const One_critical_filtration &a)
+  {
+    Base::operator=(a);
+    return *this;
+  }
+
+  // HERITAGE
 
   using std::vector<T>::operator[];
   using value_type = T;
-  using OneCritical = One_critical_filtration<T>;
-  template <typename value_type>
-  using Base = One_critical_filtration<value_type>;
+
+  // CONVERTERS
+
   operator std::vector<T> &() const { return *this; }
-  std::vector<T> get_vector() const { return static_cast<std::vector<T>>(*this); }
-  std::size_t num_parameters() const { return this->size(); }
-  // TODO : REMOVE SIZE ( confusing when kcritical)
-  // static std::size_t num_generators() {return 1;}
 
-  operator std::vector<T>() const { return static_cast<std::vector<T>>(*this); }
+  operator std::vector<T>() const { return static_cast<std::vector<T> >(*this); }
 
-  inline const std::vector<T> &as_vector() const { return *this; }
+  // needed in python
+  friend One_critical_filtration get_copy(const One_critical_filtration &f) { return f; }
 
-  inline bool is_inf() const {
-    if (this->size() != 1) return false;
-    return (this->operator[](0) == T_inf);
+  // like numpy
+  template <typename U>
+  One_critical_filtration<U> as_type() const
+  {
+    One_critical_filtration<U> out;
+    out.reserve(Base::size());
+    for (std::size_t i = 0u; i < Base::size(); i++) out.push_back(static_cast<U>(Base::operator[](i)));
+    return out;
   }
-  inline bool is_minus_inf() const {
+
+  // ACCESS
+
+  std::size_t num_parameters() const { return Base::size(); }
+
+  constexpr static One_critical_filtration inf() { return {T_inf}; }
+
+  constexpr static One_critical_filtration minus_inf() { return {-T_inf}; }
+
+  constexpr static One_critical_filtration nan()
+  {
+    if constexpr (std::numeric_limits<T>::has_quiet_NaN) {
+      return {std::numeric_limits<T>::quiet_NaN()};
+    } else {
+      return {};  // to differentiate it from 0, an empty filtration value can't do much anyway.
+    }
+  }
+
+  // DESCRIPTORS
+
+  bool is_inf() const
+  {
+    if (Base::size() != 1) return false;
+    return (Base::operator[](0) == T_inf);
+  }
+
+  bool is_minus_inf() const
+  {
     if constexpr (std::is_same<T, bool>::value) {
       return false;  // suppresses a warning
     } else {
-      if (this->size() != 1) return false;
-      return (this->operator[](0) == -T_inf);
+      if (Base::size() != 1) return false;
+      return (Base::operator[](0) == -T_inf);
     }
   }
-  inline bool is_nan() const {
-    if (this->size() != 1) return false;
-    return std::isnan(*(this->begin()));
+
+  bool is_nan() const
+  {
+    if constexpr (std::numeric_limits<T>::has_quiet_NaN) {
+      if (Base::size() != 1) return false;
+      return std::isnan(Base::operator[](0));
+    } else {
+      return Base::empty();
+    }
   }
-  inline bool is_finite() const {
-    if (this->size() > 1) return true;
-    if (this->size() == 0) return false;
-    auto first_value = *(this->begin());  // TODO : Maybe check all entries ?
+
+  bool is_finite() const
+  {
+    if (Base::size() > 1) return true;
+    if (Base::size() == 0) return false;
+    auto first_value = Base::operator[](0);  // TODO : Maybe check all entries ?
     if (std::isnan(first_value) || first_value == -T_inf || first_value == T_inf) return false;
     return true;
   }
 
-  inline friend bool operator<(const One_critical_filtration<T> &a, const One_critical_filtration<T> &b) {
+  // COMPARAISON OPERATORS
+
+  friend bool operator<(const One_critical_filtration &a, const One_critical_filtration &b)
+  {
     if (a.is_inf() || a.is_nan() || b.is_nan() || b.is_minus_inf()) return false;
     if (b.is_inf() || a.is_minus_inf()) return true;
     bool isSame = true;
     auto n = a.size();
-    assert(a.size() == b.size());
+    GUDHI_CHECK(a.size() == b.size(), "Two filtration points with different number of parameters are not comparable.");
     for (auto i = 0u; i < n; ++i) {
       if (a[i] > b[i]) return false;
       if (isSame && a[i] != b[i]) isSame = false;
     }
-    if (isSame) return false;
-    return true;
+    return !isSame;
   }
-  inline friend bool operator<=(const One_critical_filtration<T> &a, const One_critical_filtration<T> &b) {
+
+  friend bool operator<=(const One_critical_filtration &a, const One_critical_filtration &b)
+  {
     if (a.is_nan() || b.is_nan()) return false;
     if (b.is_inf() || a.is_minus_inf()) return true;
     if (a.is_inf() || b.is_minus_inf()) return false;
     auto n = a.size();
-    assert(a.size() == b.size());
+    GUDHI_CHECK(a.size() == b.size(), "Two filtration points with different number of parameters are not comparable.");
     for (std::size_t i = 0u; i < n; ++i) {
       if (a[i] > b[i]) return false;
     }
     return true;
   }
 
-  // GREATER THAN OPERATORS
-  inline friend bool operator>(const One_critical_filtration<T> &a, const One_critical_filtration<T> &b) {
-    return b < a;
-  }
-  inline friend bool operator>=(const One_critical_filtration<T> &a, const One_critical_filtration<T> &b) {
-    return b <= a;
-  }
+  friend bool operator>(const One_critical_filtration &a, const One_critical_filtration &b) { return b < a; }
 
-  inline One_critical_filtration<T> &operator=(const One_critical_filtration<T> &a) {
-    std::vector<T>::operator=(a);
-    return *this;
-  }
-  inline One_critical_filtration<T> &operator-() {
-    for (auto &truc : *this) {
-      truc = -truc;
-    }
-  }
-  inline One_critical_filtration<T> copy() const { return *this; }
+  friend bool operator>=(const One_critical_filtration &a, const One_critical_filtration &b) { return b <= a; }
 
-  std::vector<T> &_convert_back() { return *this; }
-  constexpr static One_critical_filtration<T> inf() { return {T_inf}; }
-  constexpr static One_critical_filtration<T> minus_inf() { return {-T_inf}; }
-  constexpr static One_critical_filtration<T> nan() { return {std::numeric_limits<T>::quiet_NaN()}; }
-
-  // operators *=
-  inline friend One_critical_filtration<T> &operator-=(One_critical_filtration<T> &result,
-                                                       const One_critical_filtration<T> &to_substract) {
-    if (result.is_nan() || to_substract.is_nan() || (result.is_inf() && to_substract.is_inf()) ||
-        (result.is_minus_inf() && to_substract.is_minus_inf())) [[unlikely]] {
-      result = std::numeric_limits<T>::quiet_NaN();
-      return result;
-    }
-    if (result.is_inf() || to_substract.is_minus_inf()) [[unlikely]] {
-      result = inf();
-      return result;
-    }
-    if (result.is_minus_inf() || to_substract.is_inf()) [[unlikely]] {
-      result = minus_inf();
-      return result;
-    }
-    std::transform(result.begin(), result.end(), to_substract.begin(), result.begin(), std::minus<T>());
-    return result;
-  }
-  inline friend One_critical_filtration<T> &operator+=(One_critical_filtration<T> &result,
-                                                       const One_critical_filtration<T> &to_add) {
-    if (result.is_nan() || to_add.is_nan() || (result.is_inf() && to_add.is_minus_inf()) ||
-        (result.is_minus_inf() && to_add.is_inf())) [[unlikely]] {
-      result = nan();
-      return result;
-    }
-    if (result.is_inf() || to_add.is_inf()) [[unlikely]] {
-      result = inf();
-      return result;
-    }
-    if (result.is_minus_inf() || to_add.is_minus_inf()) [[unlikely]] {
-      result = minus_inf();
-      return result;
-    }
-
-    std::transform(result.begin(), result.end(), to_add.begin(), result.begin(), std::plus<T>());
-    return result;
-  }
-  inline friend One_critical_filtration<T> &operator*=(One_critical_filtration<T> &result,
-                                                       const One_critical_filtration<T> &to_add) {
-    assert(result.is_finite() || to_add.is_finite());
-    std::transform(result.begin(), result.end(), to_add.begin(), result.begin(), std::multiplies<T>());
-    return result;
-  }
-
-  inline friend One_critical_filtration<T> &operator-=(One_critical_filtration<T> &result, const T &to_substract) {
-    for (auto &truc : result) {
-      truc -= to_substract;
-    }
-    return result;
-  }
-  inline friend One_critical_filtration<T> &operator+=(One_critical_filtration<T> &result, const T &to_add) {
-    for (auto &truc : result) {
-      truc += to_add;
-    }
-    return result;
-  }
-  inline friend One_critical_filtration<T> &operator*=(One_critical_filtration<T> &result, const T &to_add) {
-    if (to_add == T_inf || to_add == -T_inf) [[unlikely]] {
-      for (auto &truc : result) {
-        if (truc > 0)
-          truc = to_add;
-        else if (truc < 0)
-          truc = -to_add;
-        // 0*inf = 0
-      }
-      return result;
-    }
-    for (auto &truc : result) {
-      truc *= to_add;
-    }
-    return result;
-  }
-  inline friend One_critical_filtration<T> &operator/=(One_critical_filtration<T> &result, const T &to_add) {
-    for (auto &truc : result) {
-      truc /= to_add;
-    }
-    return result;
-  }
-
-  /// OPERATORS *
-  inline friend One_critical_filtration<T> operator+(One_critical_filtration<T> result, const T &to_add) {
-    result += to_add;
-    return result;
-  }
-
-  inline friend One_critical_filtration<T> operator+(One_critical_filtration<T> result,
-                                                     const One_critical_filtration<T> &to_add) {
-    result += to_add;
-    return result;
-  }
-  inline friend One_critical_filtration<T> operator-(One_critical_filtration<T> result,
-                                                     const One_critical_filtration<T> &to_add) {
-    result -= to_add;
-    return result;
-  }
-  inline friend One_critical_filtration<T> operator-(One_critical_filtration<T> result, const T &to_add) {
-    result -= to_add;
-    return result;
-  }
-  inline friend One_critical_filtration<T> operator*(One_critical_filtration<T> result, const T &to_add) {
-    result *= to_add;
-    return result;
-  }
-
-  inline friend One_critical_filtration<T> operator+(const T &to_add, const One_critical_filtration<T> &result) {
-    return result + to_add;
-  }
-  inline friend One_critical_filtration<T> operator-(const T &to_add, const One_critical_filtration<T> &result) {
-    return result - to_add;
-  }
-  inline friend One_critical_filtration<T> operator*(const T &to_add, const One_critical_filtration<T> &result) {
-    return result * to_add;
-  }
-
-  // template<class array_like>
-  inline friend bool operator==(const One_critical_filtration<T> &self, const One_critical_filtration<T> &to_compare) {
-    if (self.num_parameters() != to_compare.num_parameters()) return false;
-    auto it = to_compare.begin();
-    for (auto i = 0u; i < self.num_parameters(); i++) {
-      if (self.at(i) != *(it++)) return false;
+  friend bool operator==(const One_critical_filtration &a, const One_critical_filtration &b)
+  {
+    if (a.num_parameters() != b.num_parameters()) return false;
+    for (auto i = 0u; i < a.num_parameters(); i++) {
+      if (a[i] != b[i]) return false;
     }
     return true;
   }
 
-  inline static std::vector<std::vector<T>> to_python(const std::vector<One_critical_filtration<T>> &to_convert) {
-    return std::vector<std::vector<T>>(to_convert.begin(), to_convert.end());
+  friend bool operator!=(const One_critical_filtration &a, const One_critical_filtration &b) { return !(a == b); }
+
+  // ARITHMETIC OPERATORS
+
+  // opposite
+  friend One_critical_filtration operator-(const One_critical_filtration &f)
+  {
+    One_critical_filtration result;
+    result.reserve(f.size());
+    for (auto val : f) {
+      result.push_back(-val);
+    }
+    return result;
   }
 
-  inline static std::vector<One_critical_filtration<T>> from_python(const std::vector<std::vector<T>> &to_convert) {
-    return std::vector<One_critical_filtration<T>>(to_convert.begin(), to_convert.end());
+  // One_critical_filtration &operator-()
+  // {
+  //   for (auto &val : *this) {
+  //     val = -val;
+  //   }
+  // }
+
+  // subtraction
+  friend One_critical_filtration operator-(One_critical_filtration result, const One_critical_filtration &to_subtract)
+  {
+    result -= to_subtract;
+    return result;
   }
+
+  friend One_critical_filtration operator-(One_critical_filtration result, const T &to_subtract)
+  {
+    result -= to_subtract;
+    return result;
+  }
+
+  friend One_critical_filtration operator-(const T &value, One_critical_filtration result)
+  {
+    // TODO: in one go
+    result = -result;
+    result += value;
+    return result;
+  }
+
+  friend One_critical_filtration &operator-=(One_critical_filtration &result,
+                                             const One_critical_filtration &to_subtract)
+  {
+    if (result.empty()) return result;
+
+    if (result.is_nan() || to_subtract.is_nan() || (result.is_inf() && to_subtract.is_inf()) ||
+        (result.is_minus_inf() && to_subtract.is_minus_inf())) {
+      result = nan();
+      return result;
+    }
+    if (result.is_inf() || to_subtract.is_minus_inf()) {
+      result = inf();
+      return result;
+    }
+    if (result.is_minus_inf() || to_subtract.is_inf()) {
+      result = minus_inf();
+      return result;
+    }
+
+    GUDHI_CHECK(result.size() == to_subtract.size(),
+                "Two filtration points with different number of parameters cannot be subtracted.");
+
+    return apply_operation_with_finite_values_(result, to_subtract, subtract_);
+  }
+
+  friend One_critical_filtration &operator-=(One_critical_filtration &result, const T &to_subtract)
+  {
+    if (result.empty()) return result;
+
+    if (result.is_nan() || std::isnan(to_subtract) || (result.is_inf() && to_subtract == T_inf) ||
+        (result.is_minus_inf() && to_subtract == -T_inf)) {
+      result = nan();
+      return result;
+    }
+    if (result.is_inf() || to_subtract == -T_inf) {
+      result = inf();
+      return result;
+    }
+    if (result.is_minus_inf() || to_subtract == T_inf) {
+      result = minus_inf();
+      return result;
+    }
+
+    return apply_scalar_operation_on_finite_value_(result, to_subtract, subtract_);
+  }
+
+  // addition
+  friend One_critical_filtration operator+(One_critical_filtration result, const One_critical_filtration &to_add)
+  {
+    result += to_add;
+    return result;
+  }
+
+  friend One_critical_filtration operator+(One_critical_filtration result, const T &to_add)
+  {
+    result += to_add;
+    return result;
+  }
+
+  friend One_critical_filtration operator+(const T &to_add, One_critical_filtration result)
+  {
+    result += to_add;
+    return result;
+  }
+
+  friend One_critical_filtration &operator+=(One_critical_filtration &result, const One_critical_filtration &to_add)
+  {
+    if (result.empty()) return result;
+
+    if (result.is_nan() || to_add.is_nan() || (result.is_inf() && to_add.is_minus_inf()) ||
+        (result.is_minus_inf() && to_add.is_inf())) {
+      result = nan();
+      return result;
+    }
+    if (result.is_inf() || to_add.is_inf()) {
+      result = inf();
+      return result;
+    }
+    if (result.is_minus_inf() || to_add.is_minus_inf()) {
+      result = minus_inf();
+      return result;
+    }
+
+    GUDHI_CHECK(result.size() == to_add.size(),
+                "Two filtration points with different number of parameters cannot be added.");
+
+    return apply_operation_with_finite_values_(result, to_add, add_);
+  }
+
+  friend One_critical_filtration &operator+=(One_critical_filtration &result, const T &to_add)
+  {
+    if (result.empty()) return result;
+
+    if (result.is_nan() || std::isnan(to_add) || (result.is_inf() && to_add == -T_inf) ||
+        (result.is_minus_inf() && to_add == T_inf)) {
+      result = nan();
+      return result;
+    }
+    if (result.is_inf() || to_add == T_inf) {
+      result = inf();
+      return result;
+    }
+    if (result.is_minus_inf() || to_add == -T_inf) {
+      result = minus_inf();
+      return result;
+    }
+
+    return apply_scalar_operation_on_finite_value_(result, to_add, add_);
+  }
+
+  // multiplication
+  friend One_critical_filtration operator*(One_critical_filtration result, const One_critical_filtration &to_mul)
+  {
+    result *= to_mul;
+    return result;
+  }
+
+  friend One_critical_filtration operator*(One_critical_filtration result, const T &to_mul)
+  {
+    result *= to_mul;
+    return result;
+  }
+
+  friend One_critical_filtration operator*(const T &to_mul, One_critical_filtration result)
+  {
+    result *= to_mul;
+    return result;
+  }
+
+  friend One_critical_filtration &operator*=(One_critical_filtration &result, const One_critical_filtration &to_mul)
+  {
+    if (result.empty()) return result;
+
+    if (result.is_nan() || to_mul.is_nan()) {
+      result = nan();
+      return result;
+    }
+
+    bool res_is_infinite = result.is_inf() || result.is_minus_inf();
+    bool to_mul_is_infinite = to_mul.is_inf() || to_mul.is_minus_inf();
+
+    if (res_is_infinite && to_mul_is_infinite) {
+      if (to_mul.is_minus_inf()) {
+        result[0] = -result[0];
+      }
+      return result;
+    }
+
+    if (res_is_infinite || to_mul_is_infinite) {
+      const One_critical_filtration &finite = res_is_infinite ? to_mul : result;
+      const T infinite = res_is_infinite ? result[0] : to_mul[0];
+      result = finite;
+      return apply_scalar_operation_on_finite_value_(result, infinite, multiply_);
+    }
+
+    GUDHI_CHECK(result.size() == to_mul.size(),
+                "Two filtration points with different number of parameters cannot be multiplied.");
+
+    return apply_operation_with_finite_values_(result, to_mul, multiply_);
+  }
+
+  friend One_critical_filtration &operator*=(One_critical_filtration &result, const T &to_mul)
+  {
+    if (result.empty()) return result;
+
+    if (result.is_nan() || std::isnan(to_mul)) {
+      result = nan();
+      return result;
+    }
+
+    if (result.is_inf() || result.is_minus_inf()) {
+      if (to_mul == 0)
+        result = nan();
+      else if (to_mul < 0)
+        result[0] = -result[0];
+      return result;
+    }
+
+    return apply_scalar_operation_on_finite_value_(result, to_mul, multiply_);
+  }
+
+  // division
+  friend One_critical_filtration operator/(One_critical_filtration result, const One_critical_filtration &to_div)
+  {
+    result /= to_div;
+    return result;
+  }
+
+  friend One_critical_filtration operator/(One_critical_filtration result, const T &to_div)
+  {
+    result /= to_div;
+    return result;
+  }
+
+  friend One_critical_filtration operator/(const T &value, const One_critical_filtration &f)
+  {
+    if (f.empty()) return f;
+    if (std::isnan(value) || f.is_nan()) return nan();
+
+    One_critical_filtration result(f.size(), value);
+    result /= f;
+    return result;
+  }
+
+  friend One_critical_filtration &operator/=(One_critical_filtration &result, const One_critical_filtration &to_div)
+  {
+    if (result.empty()) return result;
+
+    bool res_is_infinite = result.is_inf() || result.is_minus_inf();
+    bool to_div_is_infinite = to_div.is_inf() || to_div.is_minus_inf();
+
+    if (result.is_nan() || to_div.is_nan() || (res_is_infinite && to_div_is_infinite)) {
+      result = nan();
+      return result;
+    }
+
+    if (to_div_is_infinite) {
+      return apply_scalar_operation_on_finite_value_with_all_nan_possible_(result, to_div[0], divide_);
+    }
+
+    GUDHI_CHECK(res_is_infinite || result.size() == to_div.size(),
+                "Two filtration points with different number of parameters cannot be divided.");
+
+    if (res_is_infinite) {
+      result.resize(to_div.size(), result[0]);
+    }
+
+    return apply_operation_with_finite_values_(result, to_div, divide_);
+  }
+
+  friend One_critical_filtration &operator/=(One_critical_filtration &result, const T &to_div)
+  {
+    if (result.empty()) return result;
+
+    bool res_is_infinite = result.is_inf() || result.is_minus_inf();
+    bool to_div_is_infinite = to_div == T_inf || to_div == -T_inf;
+
+    if (to_div == 0 || std::isnan(to_div) || result.is_nan() || (res_is_infinite && to_div_is_infinite)) {
+      result = nan();
+      return result;
+    }
+
+    if (res_is_infinite) {
+      if (to_div < 0) result[0] = -result[0];
+      return result;
+    }
+
+    return apply_scalar_operation_on_finite_value_with_all_nan_possible_(result, to_div, divide_);
+  }
+
+  // MODIFIERS
 
   /** \brief This functions take the filtration value `this` and pushes it to
    * the cone \f$ \{ y\in \mathbb R^n : y>=x \} \f$. After calling this method,
@@ -284,21 +500,19 @@ class One_critical_filtration : public std::vector<T> {
    * R^n : y>=this \}\cap \{ y\in \mathbb R^n : y>=x \}
    * @param[in] x The target filtration value on which to push `this`.
    */
-  inline void push_to(const One_critical_filtration<T> &x) {
+  void push_to(const One_critical_filtration &x)
+  {
     if (this->is_inf() || this->is_nan() || x.is_nan() || x.is_minus_inf()) return;
     if (x.is_inf() || this->is_minus_inf()) {
       *this = x;
       return;
     }
-    if (this->num_parameters() != x.num_parameters()) {
-      std::cerr << "Does only work with 1-critical filtrations ! Sizes " << this->num_parameters() << " and "
-                << x.num_parameters() << "are different !" << std::endl;
-      std::cerr << "This : " << *this << std::endl;
-      std::cerr << "arg : " << x << std::endl;
-      throw std::logic_error("Bad sizes");
-    }
+
+    GUDHI_CHECK(this->num_parameters() == x.num_parameters(),
+                "A filtration value cannot be pushed to another one with different numbers of parameters.");
+
     for (std::size_t i = 0; i < x.num_parameters(); i++)
-      this->operator[](i) = this->operator[](i) > x[i] ? this->operator[](i) : x[i];
+      Base::operator[](i) = Base::operator[](i) > x[i] ? Base::operator[](i) : x[i];
   }
 
   /** \brief This functions take the filtration value `this` and pulls it to the
@@ -307,143 +521,303 @@ class One_critical_filtration : public std::vector<T> {
    * y<=this \}\cap \{ y\in \mathbb R^n : y<=x \}
    * @param[in] x The target filtration value on which to push `this`.
    */
-  inline void pull_to(const One_critical_filtration<T> &x) {
+  void pull_to(const One_critical_filtration &x)
+  {
     if (x.is_inf() || this->is_nan() || x.is_nan() || this->is_minus_inf()) return;
     if (this->is_inf() || x.is_minus_inf()) {
       *this = x;
       return;
     }
-    if (this->num_parameters() != x.num_parameters()) {
-      std::cerr << "Does only work with 1-critical filtrations ! Sizes " << this->num_parameters() << " and "
-                << x.num_parameters() << "are different !" << std::endl;
-      std::cerr << "This : " << *this << std::endl;
-      std::cerr << "arg : " << x << std::endl;
-      throw std::logic_error("Bad sizes");
-    }
+
+    GUDHI_CHECK(this->num_parameters() == x.num_parameters(),
+                "A filtration value cannot be pulled to another one with different numbers of parameters.");
+
     for (std::size_t i = 0u; i < x.num_parameters(); i++)
-      this->operator[](i) = this->operator[](i) > x[i] ? x[i] : this->operator[](i);
+      Base::operator[](i) = Base::operator[](i) > x[i] ? x[i] : Base::operator[](i);
   }
-  // Warning, this function  assumes that the comparisons checks have already
-  // been made !
-  inline void insert_new(One_critical_filtration<T> to_concatenate) {
-    this->insert(this->end(), std::move_iterator(to_concatenate.begin()), std::move_iterator(to_concatenate.end()));
+
+  /*
+   * Same as `compute_coordinates_in_grid` but does the operation in-place
+   */
+  template <typename oned_array>
+  void project_onto_grid(const std::vector<oned_array> &grid, bool coordinate = true)
+  {
+    GUDHI_CHECK(grid.size() >= Base::size(),
+                "The grid should not be smaller than the number of parameters in the filtration value.");
+    for (std::size_t parameter = 0u; parameter < Base::size(); ++parameter) {
+      const auto &filtration = grid[parameter];
+      auto d =
+          std::distance(filtration.begin(),
+                        std::lower_bound(filtration.begin(),
+                                         filtration.end(),
+                                         static_cast<typename oned_array::value_type>(Base::operator[](parameter))));
+      Base::operator[](parameter) = coordinate ? static_cast<T>(d) : static_cast<T>(filtration[d]);
+    }
   }
+
+  // FONCTIONNALITIES
 
   // scalar product of a filtration value with x.
   template <typename U = T>
-  inline U linear_projection(const std::vector<U> &x) {
+  friend U compute_linear_projection(const One_critical_filtration &f, const std::vector<U> &x)
+  {
     U projection = 0;
-    std::size_t size = std::min(x.size(), this->size());
-    for (std::size_t i = 0u; i < size; i++) projection += x[i] * static_cast<U>(this->operator[](i));
+    std::size_t size = std::min(x.size(), f.size());
+    for (std::size_t i = 0u; i < size; i++) projection += x[i] * static_cast<U>(f[i]);
     return projection;
   }
 
-  // easy debug
-  inline friend std::ostream &operator<<(std::ostream &stream, const One_critical_filtration<T> &truc) {
-    if (truc.is_inf()) {
-      stream << "[inf, ..., inf]";
-      return stream;
-    }
-    if (truc.is_minus_inf()) {
-      stream << "[-inf, ..., -inf]";
-      return stream;
-    }
-    if (truc.is_nan()) {
-      stream << "[NaN]";
-      return stream;
-    }
-    if (truc.empty()) {
-      stream << "[]";
-      return stream;
-    }
-    stream << "[";
-    for (std::size_t i = 0; i < truc.size() - 1; i++) {
-      stream << truc[i] << ", ";
-    }
-    if (!truc.empty()) stream << truc.back();
-    stream << "]";
-    return stream;
-  }
-  inline T norm() const {
+  friend T compute_norm(const One_critical_filtration &f)
+  {
     T out = 0;
-    for (auto &stuff : *this) out += std::pow(stuff, 2);
-    return sqrt(out);
+    for (auto &val : f) out += (val * val);
+    return std::sqrt(out);
   }
-  inline T distance(const One_critical_filtration<T> &other) const {
+
+  friend T compute_euclidean_distance_to(const One_critical_filtration &f, const One_critical_filtration &other)
+  {
     T out = 0;
     for (std::size_t i = 0u; i < other.size(); i++) {
-      out += std::pow((*this)[i] - other[i], 2);
+      out += (f[i] - other[i]) * (f[i] - other[i]);
     }
-    return sqrt(out);
+    return std::sqrt(out);
   }
+
   /**
    * Given a grid in an array of shape (num_parameters, filtration_values of this parameter),
    * projects itself into this grid, and returns the coordinates of this projected points
    * in the given grid
    */
-  template <typename out_type = std::int32_t, typename U>
-  inline One_critical_filtration<out_type> coordinates_in_grid(const std::vector<std::vector<U>> &grid) const {
-    One_critical_filtration<out_type> coords(this->size());
-    assert(grid.size() >= this->size());
-    for (std::size_t parameter = 0u; parameter < grid.size(); ++parameter) {
-      const auto &filtration = grid[parameter];
-      auto C = std::distance(filtration.begin(), std::lower_bound(filtration.begin(), filtration.end(),
-                                                                  static_cast<U>(this->operator[](parameter))));
-      coords[parameter] = static_cast<out_type>(C);
-    }
+  template <typename out_type = std::int32_t, typename U = T>
+  friend One_critical_filtration<out_type> compute_coordinates_in_grid(const One_critical_filtration &f,
+                                                                       const std::vector<std::vector<U> > &grid)
+  {
+    One_critical_filtration<out_type> coords = f.as_type<out_type>();
+    coords.project_onto_grid(grid);
     return coords;
   }
+
   /**
    * Given a grid in an array of shape (num_parameters, filtration_values of this parameter),
    * and assuming that `this` correspond to the coordinates in this grid,
    * returns the points evaluated in this grid
    */
   template <typename U>
-  inline One_critical_filtration<U> evaluate_in_grid(const std::vector<std::vector<U>> &grid) const {
-    One_critical_filtration<U> pushed_value(this->size());
-    assert(grid.size() == this->size());
-    U grid_inf =
-        std::numeric_limits<U>::has_infinity ? std::numeric_limits<U>::infinity() : std::numeric_limits<U>::max();
+  friend One_critical_filtration<U> evaluate_coordinates_in_grid(const One_critical_filtration &f,
+                                                                 const std::vector<std::vector<U> > &grid)
+  {
+    One_critical_filtration<U> pushed_value(f.size());
+
+    GUDHI_CHECK(grid.size() == f.size(),
+                "The size of the grid should correspond to the number of parameters in the filtration value.");
+
+    U grid_inf = One_critical_filtration<U>::T_inf;
+
     for (std::size_t parameter = 0u; parameter < grid.size(); ++parameter) {
       const auto &filtration = grid[parameter];
-      const auto &c = this->operator[](parameter);
-      pushed_value[parameter] = c == T_inf ? grid_inf : filtration[c];
+      const auto &c = f[parameter];
+      pushed_value[parameter] = c == f.T_inf ? grid_inf : filtration[c];
     }
     return pushed_value;
   }
 
-  /*
-   * Same as `evaluate_in_grid` but does the operation in-place
-   */
-  template <typename oned_array>
-  inline void coordinates_in_grid_inplace(const std::vector<oned_array> &grid, bool coordinate = true) {
-    One_critical_filtration<std::size_t> coords(this->size());
-    assert(grid.size() >= this->size());
-    for (std::size_t parameter = 0u; parameter < grid.size(); ++parameter) {
-      const auto &filtration = grid[parameter];
-      auto d = std::distance(filtration.begin(),
-                             std::lower_bound(filtration.begin(), filtration.end(), this->operator[](parameter)));
-      this->operator[](parameter) = coordinate ? static_cast<T>(d) : static_cast<T>(grid[parameter][d]);
-      ;
+  // UTILITIES
+
+  // easy debug
+  friend std::ostream &operator<<(std::ostream &stream, const One_critical_filtration &f)
+  {
+    if (f.is_inf()) {
+      stream << "[inf, ..., inf]";
+      return stream;
     }
-  }
-  // like numpy
-  template <typename U>
-  inline One_critical_filtration<U> astype() const {
-    One_critical_filtration<U> out(this->size());
-    for (std::size_t i = 0u; i < this->size(); i++) out[i] = static_cast<U>(this->operator[](i));
-    return out;
+    if (f.is_minus_inf()) {
+      stream << "[-inf, ..., -inf]";
+      return stream;
+    }
+    if (f.is_nan()) {
+      stream << "[NaN]";
+      return stream;
+    }
+    if (f.empty()) {
+      stream << "[]";
+      return stream;
+    }
+    stream << "[";
+    for (std::size_t i = 0; i < f.size() - 1; i++) {
+      stream << f[i] << ", ";
+    }
+    if (!f.empty()) stream << f.back();
+    stream << "]";
+    return stream;
   }
 
  public:
   // TODO : maybe add the {inf}, minus inf, nan  there as static members? this
   // would make comparisons faster (just compare the ptr)
-  // TODO : I'm not sure why constexpr doens't work anymore
+  // TODO : I'm not sure why constexpr doesn't work anymore
   constexpr static const T T_inf =
       std::numeric_limits<T>::has_infinity ? std::numeric_limits<T>::infinity() : std::numeric_limits<T>::max();
 
   // for compiler
   constexpr static bool is_multi_critical = false;
+
+ private:
+  constexpr static bool subtract_(T &v1, T v2) { return add_(v1, -v2); }
+
+  constexpr static bool add_(T &v1, T v2)
+  {
+    if (std::isnan(v1) || std::isnan(v2) || (v1 == T_inf && v2 == -T_inf) || (v1 == -T_inf && v2 == T_inf)) {
+      v1 = std::numeric_limits<T>::quiet_NaN();
+      return false;
+    }
+    if (v1 == T_inf || v1 == -T_inf) {
+      return true;
+    }
+    if (v2 == T_inf || v2 == -T_inf) {
+      v1 = v2;
+      return true;
+    }
+
+    v1 += v2;
+    return true;
+  }
+
+  constexpr static bool multiply_(T &v1, T v2)
+  {
+    bool v1_is_infinite = v1 == T_inf || v1 == -T_inf;
+    bool v2_is_infinite = v2 == T_inf || v2 == -T_inf;
+
+    if (std::isnan(v1) || std::isnan(v2) || (v1_is_infinite && v2 == 0) || (v1 == 0 && v2_is_infinite)) {
+      v1 = std::numeric_limits<T>::quiet_NaN();
+      return false;
+    }
+
+    if ((v1 == T_inf && v2 > 0) || (v1 == -T_inf && v2 < 0) || (v1 < 0 && v2 == -T_inf) || (v1 > 0 && v2 == T_inf)) {
+      v1 = T_inf;
+      return true;
+    }
+
+    if ((v1 == T_inf && v2 < 0) || (v1 == -T_inf && v2 > 0) || (v1 > 0 && v2 == -T_inf) || (v1 < 0 && v2 == T_inf)) {
+      v1 = -T_inf;
+      return true;
+    }
+
+    v1 *= v2;
+    return true;
+  }
+
+  constexpr static bool divide_(T &v1, T v2)
+  {
+    bool v1_is_infinite = v1 == T_inf || v1 == -T_inf;
+    bool v2_is_infinite = v2 == T_inf || v2 == -T_inf;
+
+    if (std::isnan(v1) || std::isnan(v2) || v2 == 0 || (v1_is_infinite && v2_is_infinite)) {
+      v1 = std::numeric_limits<T>::quiet_NaN();
+      return false;
+    }
+
+    if (v1 == 0 || (v1_is_infinite && v2 > 0)) return true;
+
+    if (v1_is_infinite && v2 < 0) {
+      v1 = -v1;
+      return true;
+    }
+
+    if (v2_is_infinite) {
+      v1 = 0;
+      return true;
+    }
+
+    v1 /= v2;
+    return true;
+  }
+
+  constexpr static bool update_sign_(T toComp, int &sign)
+  {
+    if (toComp == T_inf) {
+      if (sign == 0)
+        sign = 1;
+      else if (sign == -1)
+        return false;
+    } else if (toComp == -T_inf) {
+      if (sign == 0)
+        sign = -1;
+      else if (sign == 1)
+        return false;
+    } else {
+      return false;
+    }
+
+    return true;
+  }
+
+  template <typename F>
+  static One_critical_filtration &apply_operation_with_finite_values_(One_critical_filtration &result,
+                                                                      const One_critical_filtration &to_operate,
+                                                                      F &&operate)
+  {
+    bool allSameInf = true;
+    bool allNaN = true;
+    int sign = 0;
+    for (auto i = 0u; i < result.size(); ++i) {
+      if (operate(result[i], to_operate[i])) {
+        allNaN = false;
+      } else {
+        if constexpr (!std::numeric_limits<T>::has_quiet_NaN) {
+          result = nan();
+          return result;
+        }
+      }
+      if (allSameInf) allSameInf = update_sign_(result[i], sign);
+    }
+
+    if (allSameInf) result = (sign == 1 ? inf() : minus_inf());
+    if (allNaN) result = nan();
+
+    return result;
+  }
+
+  template <typename F>
+  static One_critical_filtration &apply_scalar_operation_on_finite_value_(One_critical_filtration &result,
+                                                                          const T &to_operate,
+                                                                          F &&operate)
+  {
+    for (auto &val : result) {
+      if constexpr (std::numeric_limits<T>::has_quiet_NaN) {
+        operate(val, to_operate);
+      } else {
+        if (!operate(val, to_operate)) {
+          result = nan();
+          return result;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  template <typename F>
+  static One_critical_filtration &apply_scalar_operation_on_finite_value_with_all_nan_possible_(
+      One_critical_filtration &result,
+      const T &to_operate,
+      F &&operate)
+  {
+    bool allNaN = true;
+
+    for (auto &val : result) {
+      if (operate(val, to_operate)) {
+        allNaN = false;
+      } else {
+        if constexpr (!std::numeric_limits<T>::has_quiet_NaN) {
+          result = nan();
+          return result;
+        }
+      }
+    }
+    if (allNaN) result = nan();
+
+    return result;
+  }
 };
 
 }  // namespace Gudhi::multi_filtration
@@ -451,21 +825,38 @@ class One_critical_filtration : public std::vector<T> {
 namespace std {
 
 template <typename T>
-class numeric_limits<Gudhi::multi_filtration::One_critical_filtration<T>> {
+class numeric_limits<Gudhi::multi_filtration::One_critical_filtration<T> >
+{
  public:
-  static constexpr bool has_infinity = std::numeric_limits<T>::has_infinity;
+  static constexpr bool has_infinity = true;
 
-  static Gudhi::multi_filtration::One_critical_filtration<T> infinity() throw() {
-    return Gudhi::multi_filtration::One_critical_filtration<T>(1, std::numeric_limits<T>::infinity());
+  static constexpr Gudhi::multi_filtration::One_critical_filtration<T> infinity() noexcept
+  {
+    return Gudhi::multi_filtration::One_critical_filtration<T>::inf();
   };
-  static Gudhi::multi_filtration::One_critical_filtration<T> minus_infinity() throw() {
-    return Gudhi::multi_filtration::One_critical_filtration<T>(1, -std::numeric_limits<T>::infinity());
+
+  // non-standard
+  static constexpr Gudhi::multi_filtration::One_critical_filtration<T> minus_infinity() noexcept
+  {
+    return Gudhi::multi_filtration::One_critical_filtration<T>::minus_inf();
   };
-  static Gudhi::multi_filtration::One_critical_filtration<T> max() throw() {
-    return Gudhi::multi_filtration::One_critical_filtration<T>(1, std::numeric_limits<T>::max());
+
+  static constexpr Gudhi::multi_filtration::One_critical_filtration<T> max() noexcept(false)
+  {
+    throw std::logic_error(
+        "The maximal value cannot be represented with no finite numbers of parameters."
+        "Use `max(number_of_parameters)` instead");
   };
-  static Gudhi::multi_filtration::One_critical_filtration<T> quiet_NaN() throw() {
-    return Gudhi::multi_filtration::One_critical_filtration<T>(1, numeric_limits<T>::quiet_NaN());
+
+  // non-standard, so I don't want to define a default value.
+  static constexpr Gudhi::multi_filtration::One_critical_filtration<T> max(unsigned int n) noexcept
+  {
+    return Gudhi::multi_filtration::One_critical_filtration<T>(n, std::numeric_limits<T>::max());
+  };
+
+  static constexpr Gudhi::multi_filtration::One_critical_filtration<T> quiet_NaN() noexcept
+  {
+    return Gudhi::multi_filtration::One_critical_filtration<T>::nan();
   };
 };
 

--- a/src/Multi_filtration/test/CMakeLists.txt
+++ b/src/Multi_filtration/test/CMakeLists.txt
@@ -1,0 +1,4 @@
+include(GUDHI_boost_test)
+
+add_executable_with_targets(Multi_filtration_onecritical_unit_test multifiltration_onecritical_unit_test.cpp TBB::tbb)
+gudhi_add_boost_test(Multi_filtration_onecritical_unit_test)

--- a/src/Multi_filtration/test/multifiltration_onecritical_unit_test.cpp
+++ b/src/Multi_filtration/test/multifiltration_onecritical_unit_test.cpp
@@ -1,0 +1,509 @@
+/*    This file is part of the Gudhi Library - https://gudhi.inria.fr/ - which is released under MIT.
+ *    See file LICENSE or go to https://gudhi.inria.fr/licensing/ for full license details.
+ *    Author(s):       Hannah Schreiber
+ *
+ *    Copyright (C) 2024 Inria
+ *
+ *    Modification(s):
+ *      - YYYY/MM Author: Description of the modification
+ */
+
+#include <boost/test/tools/old/interface.hpp>
+#include <cmath>
+#include <limits>
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE "multi_filtration"
+#include <boost/test/unit_test.hpp>
+#include <boost/mpl/list.hpp>
+
+#include <gudhi/One_critical_filtration.h>
+
+using Gudhi::multi_filtration::One_critical_filtration;
+
+typedef boost::mpl::list<double, float, int> list_of_tested_variants;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(one_critical_filtration_constructors, T, list_of_tested_variants)
+{
+  One_critical_filtration<T> f;
+  BOOST_CHECK(f.empty());
+  BOOST_CHECK(f.num_parameters() == 0);
+
+  One_critical_filtration<T> f1(3);
+  BOOST_CHECK(f1.size() == 3);
+  BOOST_CHECK(f1.num_parameters() == 3);
+  BOOST_CHECK(f1[0] == -One_critical_filtration<T>::T_inf);
+
+  One_critical_filtration<T> f2(3, 0);
+  BOOST_CHECK(f2.size() == 3);
+  BOOST_CHECK(f2.num_parameters() == 3);
+  BOOST_CHECK(f2[0] == 0);
+
+  One_critical_filtration<T> f3({0, 1, 2});
+  BOOST_CHECK(f3.size() == 3);
+  BOOST_CHECK(f3.num_parameters() == 3);
+  BOOST_CHECK(f3[0] == 0);
+  BOOST_CHECK(f3[1] == 1);
+  BOOST_CHECK(f3[2] == 2);
+
+  std::vector<T> v{0, 1, 2};
+  One_critical_filtration<T> f4(v);
+  BOOST_CHECK(f4.size() == 3);
+  BOOST_CHECK(f4.num_parameters() == 3);
+  BOOST_CHECK(f4[0] == 0);
+  BOOST_CHECK(f4[1] == 1);
+  BOOST_CHECK(f4[2] == 2);
+
+  One_critical_filtration<T> f5(v.begin(), v.end());
+  BOOST_CHECK(f5.size() == 3);
+  BOOST_CHECK(f5.num_parameters() == 3);
+  BOOST_CHECK(f5[0] == 0);
+  BOOST_CHECK(f5[1] == 1);
+  BOOST_CHECK(f5[2] == 2);
+
+  f = f5;
+  BOOST_CHECK(f.size() == 3);
+  BOOST_CHECK(f.num_parameters() == 3);
+  BOOST_CHECK(f[0] == 0);
+  BOOST_CHECK(f[1] == 1);
+  BOOST_CHECK(f[2] == 2);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(one_critical_filtration_utilities, T, list_of_tested_variants)
+{
+  One_critical_filtration<T> f({0, 1, 2});
+  bool test = std::is_same_v<decltype(f[0]), T&>;
+  BOOST_CHECK(test);
+
+  One_critical_filtration<float> f2 = f.template as_type<float>();
+  test = std::is_same_v<decltype(f2[0]), float&>;
+  BOOST_CHECK(test);
+  BOOST_CHECK(f2.size() == 3);
+  BOOST_CHECK(f2.num_parameters() == 3);
+  BOOST_CHECK(f2[0] == 0.);
+  BOOST_CHECK(f2[1] == 1.);
+  BOOST_CHECK(f2[2] == 2.);
+
+  BOOST_CHECK(!f.is_inf());
+  BOOST_CHECK(!f.is_minus_inf());
+  BOOST_CHECK(!f.is_nan());
+  BOOST_CHECK(f.is_finite());
+
+  One_critical_filtration<T> f3;
+  BOOST_CHECK(!f3.is_inf());
+  BOOST_CHECK(!f3.is_minus_inf());
+  if constexpr (std::numeric_limits<T>::has_quiet_NaN){
+    BOOST_CHECK(!f3.is_nan());
+  } else {
+    BOOST_CHECK(f3.is_nan()); //by default nan if T has no nan
+  }
+  BOOST_CHECK(!f3.is_finite());
+
+  //{-inf, -inf, -inf} is considered finite as the user is supposed to updates the values to something else
+  //the idea is just to reserve space and to give the possibility to use `f4[i] =`
+  //if the value should really be -inf, use `f4(1)` or `f4 = minus_inf()` instead.
+  One_critical_filtration<T> f4(3);
+  BOOST_CHECK(!f4.is_inf());
+  BOOST_CHECK(!f4.is_minus_inf());
+  BOOST_CHECK(!f4.is_nan());
+  BOOST_CHECK(f4.is_finite());
+
+  One_critical_filtration<T> f5(1);
+  BOOST_CHECK(!f5.is_inf());
+  BOOST_CHECK(f5.is_minus_inf());
+  BOOST_CHECK(!f5.is_nan());
+  BOOST_CHECK(!f5.is_finite());
+
+  auto f6 = One_critical_filtration<T>::nan();
+  BOOST_CHECK(!f6.is_inf());
+  BOOST_CHECK(!f6.is_minus_inf());
+  BOOST_CHECK(f6.is_nan());
+  BOOST_CHECK(!f6.is_finite());
+
+  auto f7 = One_critical_filtration<T>::inf();
+  BOOST_CHECK(f7.is_inf());
+  BOOST_CHECK(!f7.is_minus_inf());
+  BOOST_CHECK(!f7.is_nan());
+  BOOST_CHECK(!f7.is_finite());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(one_critical_filtration_comparators, T, list_of_tested_variants)
+{
+  One_critical_filtration<T> f1({0, 1, 2});
+  One_critical_filtration<T> f2({-1, 0, 1});
+  One_critical_filtration<T> f3({1, 2, 3});
+  One_critical_filtration<T> f4({5, -1, 2});
+
+  BOOST_CHECK(!(f1 < f1));
+  BOOST_CHECK(!(f1 < f2));
+  BOOST_CHECK(f1 < f3);
+  BOOST_CHECK(!(f1 < f4));
+  BOOST_CHECK(!(f1 < One_critical_filtration<T>::nan()));
+  BOOST_CHECK(f1 < One_critical_filtration<T>::inf());
+  BOOST_CHECK(!(f1 < One_critical_filtration<T>::minus_inf()));
+
+  BOOST_CHECK(f1 <= f1);
+  BOOST_CHECK(!(f1 <= f2));
+  BOOST_CHECK(f1 <= f3);
+  BOOST_CHECK(!(f1 <= f4));
+  BOOST_CHECK(!(f1 <= One_critical_filtration<T>::nan()));
+  BOOST_CHECK(f1 <= One_critical_filtration<T>::inf());
+  BOOST_CHECK(!(f1 <= One_critical_filtration<T>::minus_inf()));
+
+  BOOST_CHECK(!(f1 > f1));
+  BOOST_CHECK(f1 > f2);
+  BOOST_CHECK(!(f1 > f3));
+  BOOST_CHECK(!(f1 > f4));
+  BOOST_CHECK(!(f1 > One_critical_filtration<T>::nan()));
+  BOOST_CHECK(!(f1 > One_critical_filtration<T>::inf()));
+  BOOST_CHECK(f1 > One_critical_filtration<T>::minus_inf());
+
+  BOOST_CHECK(f1 >= f1);
+  BOOST_CHECK(f1 >= f2);
+  BOOST_CHECK(!(f1 >= f3));
+  BOOST_CHECK(!(f1 >= f4));
+  BOOST_CHECK(!(f1 >= One_critical_filtration<T>::nan()));
+  BOOST_CHECK(!(f1 >= One_critical_filtration<T>::inf()));
+  BOOST_CHECK(f1 >= One_critical_filtration<T>::minus_inf());
+
+  BOOST_CHECK(f1 == f1);
+  BOOST_CHECK(!(f1 == f2));
+  BOOST_CHECK(!(f1 == f3));
+  BOOST_CHECK(!(f1 == f4));
+  BOOST_CHECK(!(f1 == One_critical_filtration<T>::nan()));
+  BOOST_CHECK(!(f1 == One_critical_filtration<T>::inf()));
+  BOOST_CHECK(!(f1 == One_critical_filtration<T>::minus_inf()));
+
+  BOOST_CHECK(!(f1 != f1));
+  BOOST_CHECK(f1 != f2);
+  BOOST_CHECK(f1 != f3);
+  BOOST_CHECK(f1 != f4);
+  BOOST_CHECK(f1 != One_critical_filtration<T>::nan());
+  BOOST_CHECK(f1 != One_critical_filtration<T>::inf());
+  BOOST_CHECK(f1 != One_critical_filtration<T>::minus_inf());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(one_critical_filtration_operators, T, list_of_tested_variants)
+{;
+  One_critical_filtration<T> f({-10, 0, 1});
+  One_critical_filtration<T> f2({5, 2, -1});
+  One_critical_filtration<T> f3(
+      {-One_critical_filtration<T>::T_inf, One_critical_filtration<T>::T_inf, -One_critical_filtration<T>::T_inf});
+  One_critical_filtration<T> f4(
+      {One_critical_filtration<T>::T_inf, -One_critical_filtration<T>::T_inf, One_critical_filtration<T>::T_inf});
+
+  auto res = -f;
+  BOOST_CHECK_EQUAL(res[0], 10);
+  BOOST_CHECK_EQUAL(res[1], 0);
+  BOOST_CHECK_EQUAL(res[2], -1);
+  BOOST_CHECK((-One_critical_filtration<T>::inf()).is_minus_inf());
+  BOOST_CHECK((-One_critical_filtration<T>::minus_inf()).is_inf());
+  BOOST_CHECK((-One_critical_filtration<T>::nan()).is_nan());
+
+  res = f - f2;
+  BOOST_CHECK_EQUAL(res[0], -15);
+  BOOST_CHECK_EQUAL(res[1], -2);
+  BOOST_CHECK_EQUAL(res[2], 2);
+
+  res = f - f3;
+  BOOST_CHECK_EQUAL(res[0], f4[0]);
+  BOOST_CHECK_EQUAL(res[1], f4[1]);
+  BOOST_CHECK_EQUAL(res[2], f4[2]);
+
+  res = f3 - f;
+  BOOST_CHECK_EQUAL(res[0], f3[0]);
+  BOOST_CHECK_EQUAL(res[1], f3[1]);
+  BOOST_CHECK_EQUAL(res[2], f3[2]);
+
+  res = 5 - f;
+  BOOST_CHECK_EQUAL(res[0], 15);
+  BOOST_CHECK_EQUAL(res[1], 5);
+  BOOST_CHECK_EQUAL(res[2], 4);
+
+  res = f - 5;
+  BOOST_CHECK_EQUAL(res[0], -15);
+  BOOST_CHECK_EQUAL(res[1], -5);
+  BOOST_CHECK_EQUAL(res[2], -4);
+
+  BOOST_CHECK((f - One_critical_filtration<T>::inf()).is_minus_inf());
+  BOOST_CHECK((One_critical_filtration<T>::inf() - f).is_inf());
+  BOOST_CHECK((f - One_critical_filtration<T>::minus_inf()).is_inf());
+  BOOST_CHECK((One_critical_filtration<T>::minus_inf() - f).is_minus_inf());
+  BOOST_CHECK((f - One_critical_filtration<T>::nan()).is_nan());
+  BOOST_CHECK((One_critical_filtration<T>::nan() - f).is_nan());
+
+  res = f3 - f3;
+  BOOST_CHECK(res.is_nan());
+  res = f3 - f4;
+  BOOST_CHECK_EQUAL(res[0], f3[0]);
+  BOOST_CHECK_EQUAL(res[1], f3[1]);
+  BOOST_CHECK_EQUAL(res[2], f3[2]);
+
+  res = f + f2;
+  BOOST_CHECK_EQUAL(res[0], -5);
+  BOOST_CHECK_EQUAL(res[1], 2);
+  BOOST_CHECK_EQUAL(res[2], 0);
+
+  res = f + f3;
+  BOOST_CHECK_EQUAL(res[0], f3[0]);
+  BOOST_CHECK_EQUAL(res[1], f3[1]);
+  BOOST_CHECK_EQUAL(res[2], f3[2]);
+
+  res = 5 + f;
+  BOOST_CHECK_EQUAL(res[0], -5);
+  BOOST_CHECK_EQUAL(res[1], 5);
+  BOOST_CHECK_EQUAL(res[2], 6);
+
+  res = f + 5;
+  BOOST_CHECK_EQUAL(res[0], -5);
+  BOOST_CHECK_EQUAL(res[1], 5);
+  BOOST_CHECK_EQUAL(res[2], 6);
+
+  BOOST_CHECK((f + One_critical_filtration<T>::inf()).is_inf());
+  BOOST_CHECK((One_critical_filtration<T>::inf() + f).is_inf());
+  BOOST_CHECK((f + One_critical_filtration<T>::minus_inf()).is_minus_inf());
+  BOOST_CHECK((One_critical_filtration<T>::minus_inf() + f).is_minus_inf());
+  BOOST_CHECK((f + One_critical_filtration<T>::nan()).is_nan());
+  BOOST_CHECK((One_critical_filtration<T>::nan() + f).is_nan());
+
+  res = f3 + f4;
+  BOOST_CHECK(res.is_nan());
+  res = f3 + f3;
+  BOOST_CHECK_EQUAL(res[0], f3[0]);
+  BOOST_CHECK_EQUAL(res[1], f3[1]);
+  BOOST_CHECK_EQUAL(res[2], f3[2]);
+
+  res = f * f2;
+  BOOST_CHECK_EQUAL(res[0], -50);
+  BOOST_CHECK_EQUAL(res[1], 0);
+  BOOST_CHECK_EQUAL(res[2], -1);
+
+  res = f * f3;
+  if constexpr (std::numeric_limits<T>::has_quiet_NaN){
+    BOOST_CHECK_EQUAL(res[0], f4[0]);
+    BOOST_CHECK(std::isnan(res[1]));
+    BOOST_CHECK_EQUAL(res[2], f3[2]);
+  } else {
+    BOOST_CHECK(res.is_nan());
+  }
+
+  res = 5 * f;
+  BOOST_CHECK_EQUAL(res[0], -50);
+  BOOST_CHECK_EQUAL(res[1], 0);
+  BOOST_CHECK_EQUAL(res[2], 5);
+
+  res = f * 5;
+  BOOST_CHECK_EQUAL(res[0], -50);
+  BOOST_CHECK_EQUAL(res[1],  0);
+  BOOST_CHECK_EQUAL(res[2], 5);
+
+  res = f * One_critical_filtration<T>::inf();
+  if constexpr (std::numeric_limits<T>::has_quiet_NaN){
+    BOOST_CHECK_EQUAL(res[0], -One_critical_filtration<T>::T_inf);
+    BOOST_CHECK(std::isnan(res[1]));
+    BOOST_CHECK_EQUAL(res[2], One_critical_filtration<T>::T_inf);
+  } else {
+    BOOST_CHECK(res.is_nan());
+  }
+  res = One_critical_filtration<T>::inf() * f;
+  if constexpr (std::numeric_limits<T>::has_quiet_NaN){
+    BOOST_CHECK_EQUAL(res[0], -One_critical_filtration<T>::T_inf);
+    BOOST_CHECK(std::isnan(res[1]));
+    BOOST_CHECK_EQUAL(res[2], One_critical_filtration<T>::T_inf);
+  } else {
+    BOOST_CHECK(res.is_nan());
+  }
+  res = f * One_critical_filtration<T>::minus_inf();
+  if constexpr (std::numeric_limits<T>::has_quiet_NaN){
+    BOOST_CHECK_EQUAL(res[0], One_critical_filtration<T>::T_inf);
+    BOOST_CHECK(std::isnan(res[1]));
+    BOOST_CHECK_EQUAL(res[2], -One_critical_filtration<T>::T_inf);
+  } else {
+    BOOST_CHECK(res.is_nan());
+  }
+  res = One_critical_filtration<T>::minus_inf() * f;
+  if constexpr (std::numeric_limits<T>::has_quiet_NaN){
+    BOOST_CHECK_EQUAL(res[0], One_critical_filtration<T>::T_inf);
+    BOOST_CHECK(std::isnan(res[1]));
+    BOOST_CHECK_EQUAL(res[2], -One_critical_filtration<T>::T_inf);
+  } else {
+    BOOST_CHECK(res.is_nan());
+  }
+  res = f * One_critical_filtration<T>::nan();
+  BOOST_CHECK(res.is_nan());
+  res = One_critical_filtration<T>::nan() * f;
+  BOOST_CHECK(res.is_nan());
+
+  res = f3 * f3;
+  BOOST_CHECK(res.is_inf());
+  res = f3 * f4;
+  BOOST_CHECK(res.is_minus_inf());
+
+  res = f / f2;
+  BOOST_CHECK_EQUAL(res[0], -2);
+  BOOST_CHECK_EQUAL(res[1], 0);
+  BOOST_CHECK_EQUAL(res[2], -1);
+
+  res = f / f3;
+  BOOST_CHECK_EQUAL(res[0], 0);
+  BOOST_CHECK_EQUAL(res[1], 0);
+  BOOST_CHECK_EQUAL(res[2], 0);
+
+  res = f3 / f;
+  if constexpr (std::numeric_limits<T>::has_quiet_NaN){
+    BOOST_CHECK_EQUAL(res[0], f4[0]);
+    BOOST_CHECK(std::isnan(res[1]));
+    BOOST_CHECK_EQUAL(res[2], f3[2]);
+  } else {
+    BOOST_CHECK(res.is_nan());
+  }
+
+  res = 5 / f;
+  if constexpr (std::numeric_limits<T>::has_quiet_NaN){
+    BOOST_CHECK_EQUAL(res[0], -0.5);
+    BOOST_CHECK(std::isnan(res[1]));
+    BOOST_CHECK_EQUAL(res[2], 5);
+  } else {
+    BOOST_CHECK(res.is_nan());
+  }
+
+  res = f / 5;
+  BOOST_CHECK_EQUAL(res[0], -2);
+  BOOST_CHECK_EQUAL(res[1],  0);
+  BOOST_CHECK_EQUAL(res[2], static_cast<T>(1) / static_cast<T>(5)); //to avoid precision error
+
+  res = f / One_critical_filtration<T>::inf();
+  BOOST_CHECK_EQUAL(res[0], 0);
+  BOOST_CHECK_EQUAL(res[1], 0);
+  BOOST_CHECK_EQUAL(res[2], 0);
+  res = One_critical_filtration<T>::inf() / f;
+  if constexpr (std::numeric_limits<T>::has_quiet_NaN){
+    BOOST_CHECK_EQUAL(res[0], -One_critical_filtration<T>::T_inf);
+    BOOST_CHECK(std::isnan(res[1]));
+    BOOST_CHECK_EQUAL(res[2], One_critical_filtration<T>::T_inf);
+  } else {
+    BOOST_CHECK(res.is_nan());
+  }
+  res = f / One_critical_filtration<T>::minus_inf();
+  BOOST_CHECK_EQUAL(res[0], 0);
+  BOOST_CHECK_EQUAL(res[1], 0);
+  BOOST_CHECK_EQUAL(res[2], 0);
+  res = One_critical_filtration<T>::minus_inf() / f;
+  if constexpr (std::numeric_limits<T>::has_quiet_NaN){
+    BOOST_CHECK_EQUAL(res[0], One_critical_filtration<T>::T_inf);
+    BOOST_CHECK(std::isnan(res[1]));
+    BOOST_CHECK_EQUAL(res[2], -One_critical_filtration<T>::T_inf);
+  } else {
+    BOOST_CHECK(res.is_nan());
+  }
+  res = f / One_critical_filtration<T>::nan();
+  BOOST_CHECK(res.is_nan());
+  res = One_critical_filtration<T>::nan() / f;
+  BOOST_CHECK(res.is_nan());
+
+  res = f3 / f3;
+  BOOST_CHECK(res.is_nan());
+  res = f3 / f4;
+  BOOST_CHECK(res.is_nan());
+  res = f / One_critical_filtration<T>({0, 0, 0});
+  BOOST_CHECK(res.is_nan());
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(one_critical_filtration_modifiers, T, list_of_tested_variants)
+{
+  One_critical_filtration<T> f({0, 1, 2});
+  BOOST_CHECK_EQUAL(f[0], 0);
+  BOOST_CHECK_EQUAL(f[1], 1);
+  BOOST_CHECK_EQUAL(f[2], 2);
+
+  f.push_to({-1, 5, 6});
+  BOOST_CHECK_EQUAL(f[0], 0);
+  BOOST_CHECK_EQUAL(f[1], 5);
+  BOOST_CHECK_EQUAL(f[2], 6);
+
+  f.push_to({-1, -5, -6});
+  BOOST_CHECK_EQUAL(f[0], 0);
+  BOOST_CHECK_EQUAL(f[1], 5);
+  BOOST_CHECK_EQUAL(f[2], 6);
+
+  f.push_to(One_critical_filtration<T>::minus_inf());
+  BOOST_CHECK_EQUAL(f[0], 0);
+  BOOST_CHECK_EQUAL(f[1], 5);
+  BOOST_CHECK_EQUAL(f[2], 6);
+
+  f.push_to(One_critical_filtration<T>::inf());
+  BOOST_CHECK(f.is_inf());
+
+  f.push_to(One_critical_filtration<T>::nan());
+  BOOST_CHECK(f.is_inf());
+
+  f.pull_to({-1, 5, 6});
+  BOOST_CHECK_EQUAL(f[0], -1);
+  BOOST_CHECK_EQUAL(f[1], 5);
+  BOOST_CHECK_EQUAL(f[2], 6);
+
+  f.pull_to({1, 8, 9});
+  BOOST_CHECK_EQUAL(f[0], -1);
+  BOOST_CHECK_EQUAL(f[1], 5);
+  BOOST_CHECK_EQUAL(f[2], 6);
+
+  f.pull_to(One_critical_filtration<T>::inf());
+  BOOST_CHECK_EQUAL(f[0], -1);
+  BOOST_CHECK_EQUAL(f[1], 5);
+  BOOST_CHECK_EQUAL(f[2], 6);
+
+  f.pull_to(One_critical_filtration<T>::minus_inf());
+  BOOST_CHECK(f.is_minus_inf());
+
+  f.pull_to(One_critical_filtration<T>::nan());
+  BOOST_CHECK(f.is_minus_inf());
+
+  std::vector<std::vector<int> > grid = {{0, 2, 4, 8}, {0, 3, 6, 9}, {0, 4, 8, 16}};
+
+  f.push_to({1, 7, 5});
+  f.project_onto_grid(grid, true);
+  BOOST_CHECK_EQUAL(f[0], 1);
+  BOOST_CHECK_EQUAL(f[1], 3);
+  BOOST_CHECK_EQUAL(f[2], 2);
+
+  f.push_to({1, 7, 5});
+  f.project_onto_grid(grid, false);
+  BOOST_CHECK_EQUAL(f[0], 2);
+  BOOST_CHECK_EQUAL(f[1], 9);
+  BOOST_CHECK_EQUAL(f[2], 8);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(one_critical_filtration_friends, T, list_of_tested_variants)
+{
+  One_critical_filtration<T> f({0, 1, 2});
+  
+  BOOST_CHECK_EQUAL(compute_linear_projection(f, {2,3,5,9}), 13);
+  BOOST_CHECK_EQUAL(compute_norm(f), static_cast<T>(std::sqrt(T(5))));
+  BOOST_CHECK_EQUAL(compute_euclidean_distance_to(f, {2,3,5}), static_cast<T>(std::sqrt(T(17))));
+
+  f = {1, 7, 5};
+
+  std::vector<std::vector<int> > grid = {{0, 2, 4, 8}, {0, 3, 6, 9}, {0, 4, 8, 16}};
+  auto res = compute_coordinates_in_grid(f, grid);
+  BOOST_CHECK_EQUAL(res[0], 1);
+  BOOST_CHECK_EQUAL(res[1], 3);
+  BOOST_CHECK_EQUAL(res[2], 2);
+
+  res = evaluate_coordinates_in_grid(res, grid);
+  BOOST_CHECK_EQUAL(res[0], 2);
+  BOOST_CHECK_EQUAL(res[1], 9);
+  BOOST_CHECK_EQUAL(res[2], 8);
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(one_critical_filtration_numerical_limits, T, list_of_tested_variants)
+{
+  BOOST_CHECK(std::numeric_limits<One_critical_filtration<T> >::has_infinity);
+  BOOST_CHECK(std::numeric_limits<One_critical_filtration<T> >::infinity().is_inf());
+  BOOST_CHECK(std::numeric_limits<One_critical_filtration<T> >::quiet_NaN().is_nan());
+  BOOST_CHECK_THROW(std::numeric_limits<One_critical_filtration<T> >::max(), std::logic_error);
+  auto max = std::numeric_limits<One_critical_filtration<T> >::max(3);
+  BOOST_CHECK_EQUAL(max[0], std::numeric_limits<T>::max());
+  BOOST_CHECK_EQUAL(max[1], std::numeric_limits<T>::max());
+  BOOST_CHECK_EQUAL(max[2], std::numeric_limits<T>::max());
+}
+


### PR DESCRIPTION
Works now for all signed arithmetic types + added unit tests
TODO: Still misses proper doc

Removed methods are methods not used at all in multipers (even not in the python part).